### PR TITLE
Clean-up, add async fetch logic for articles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ tui = "0.19.0"
 url = "2.3.1"
 rss = "2.0.4"
 reqwest = "0.11.18"
+futures = "0.3" # for our async / await blocks
+tokio = { version = "1.12.0", features = ["full"] } # for our async runtime
 
 #[[bin]]
 #name = "newsroom"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,4 @@
 use tui::widgets::TableState;
-use url::Url;
 
 mod newsroomcore;
 

--- a/src/app/newsroomcore/newsarticle.rs
+++ b/src/app/newsroomcore/newsarticle.rs
@@ -1,16 +1,14 @@
-use url::Url;
-
 use super::newsroomstate::data_sources;
 
 // This struct represents the data that we
 // Actually care about extracting from the news API
 #[derive(Debug)]
 pub struct news_article{
-    authors: Vec<String>,
-    title: String,
-    summary: String,
-    link: Url,
-    source: data_sources,
+    pub authors: Vec<String>,
+    pub title: String,
+    pub summary: String,
+    pub link: String,
+    pub source: data_sources,
 }
 
 impl news_article {

--- a/src/app/newsroomcore/newsfetchrss.rs
+++ b/src/app/newsroomcore/newsfetchrss.rs
@@ -1,18 +1,10 @@
 // Code section to fetch RSS data in a way we can understand
 use rss::Channel;
-use url::Url;
 use std::error::Error;
 use reqwest::Request;
 
-use super::newsarticle::news_article;
+use super::{newsarticle::news_article, newsroomstate::data_sources};
 
-// struct Contents {
-//     contents: str,
-// }
-
-// fn fetch(url: Url) -> Vec<Contents> {
-    
-// }
 
 async fn get_channel(url : &str) -> Result<Channel, Box<dyn Error>> {
     let content = reqwest::get(url)
@@ -23,6 +15,81 @@ async fn get_channel(url : &str) -> Result<Channel, Box<dyn Error>> {
     Ok(channel)
 }
 
-pub fn fetch_rss_feed(url: Url) -> Vec<news_article>{
-    todo!()
+fn channel_to_articles(channel: Channel, data_source: data_sources) -> Result<Vec<news_article>, Box<dyn Error>>{
+    // Take in a channel and reformat into a vector of news articles
+
+    let mut articles: Vec<news_article> = Vec::new();
+    for item in channel.items(){
+        match item.description(){
+            Some(description) => {
+                // Extract the data we need from item
+
+                // Author
+                let author: Vec<String> = match item.author(){
+                    Some(auth) => vec![auth.to_string()],
+                    None => vec!["".to_string()],
+                };
+
+                // Title
+                let title: String = match item.title() {
+                    Some(tit) => tit.to_string(),
+                    None => "".to_string(),
+                };
+                
+                // Summary (We've already unwrapped this)
+                let summary = description.to_string();
+
+                // Link
+                let link = match item.link() {
+                    Some(url) => url.to_string(),
+                    None => "".to_string(),
+                };
+
+                let article_to_push: news_article = news_article{ authors: author, title: title, summary: summary, link, source: data_source.clone() };
+                articles.push(article_to_push);
+            },
+            None => {},
+        }
+    }
+    Ok(articles)
+}
+
+pub async fn fetch_rss_feed(source: data_sources) -> Result<Vec<news_article>, Box<dyn Error>>{
+    let channel = get_channel(&source.url).await?;
+    channel_to_articles(channel, source)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Test that we're able to correctly read from the CBC rss channel
+    #[tokio::test]
+    async fn test_rss_fetch(){
+        let ch = get_channel("https://www.cbc.ca/cmlink/rss-topstories").await.unwrap();
+        let items = ch.items();
+        println!("{}", items.len());
+        let entry = &items[0];
+        // let entry_str = entry.content().unwrap();
+        // println!("{}", entry_str);
+        assert_eq!(ch.title(), "CBC | Top Stories News ");
+    }
+
+    #[tokio::test]
+    async fn test_channel_to_articles(){
+        let source: data_sources = data_sources { name: "CBC".to_string(), url: "https://www.cbc.ca/cmlink/rss-topstories".to_string() };
+        let ch = get_channel(&source.url).await.unwrap();
+        let articles = channel_to_articles(ch, source).unwrap();
+        assert!(articles.len() > 0); //Make sure that we can pull some articles
+        // println!("{:#?}", articles);
+    }
+
+    #[tokio::test]
+    async fn test_public_fn(){
+        let source: data_sources = data_sources { name: "CBC".to_string(), url: "https://www.cbc.ca/cmlink/rss-topstories".to_string() };
+        let articles = fetch_rss_feed(source).await.unwrap();
+        assert!(articles.len() > 0); //Make sure that we can pull some articles
+        println!("{:#?}", articles);
+    }
+
 }

--- a/src/app/newsroomcore/newsroomstate.rs
+++ b/src/app/newsroomcore/newsroomstate.rs
@@ -1,5 +1,3 @@
-use url::Url;
-
 use super::newsarticle::news_article;
 
 // Enum to represent our own app state
@@ -24,12 +22,10 @@ pub enum newsroom_transitions{
 // This enum represents our data providers
 // Later on we can store data for each API
 // Inside the enum fields 
-#[derive(Debug)]
-pub enum data_sources {
-    associated_press,
-    bbc,
-    cbc,
-    cnn,
+#[derive(Debug, Clone)]
+pub struct data_sources {
+    pub name: String,
+    pub url: String,
 }
 
 impl data_sources {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(warnings, unused)]
 mod ui;
 mod app;
 


### PR DESCRIPTION
This PR contains some general clean up and the logic for the async feature in the newsroomcore module.

It allows us to fetch a vector of news articles from a datasource structure (url and name) and get back a newsroom struct with information for the article.
Importantly we do not process the description at the moment (which is html) so we'll need to do that at some point to make it easier to read since most have images.