### PR TITLE
Reduce idle cpu

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -14,8 +14,6 @@ pub enum Event {
     Mouse(MouseEvent),
     /// Terminal resize.
     Resize(u16, u16),
-    /// Nothing, dont do anything
-    Nothing,
 }
 
 /// Terminal event handler.
@@ -76,11 +74,10 @@ impl EventHandler {
     ///
     /// This function will always block the current thread if
     /// there is no data available and it's possible for more data to be sent.
-    pub fn next(&mut self) -> AppResult<Event> {
-        match self.receiver.try_recv() {
-            Ok(app_result) => AppResult::Ok(app_result),
-            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => AppResult::Ok(Event::Nothing),
-            Err(_) => AppResult::Err("".into()),
+    pub async fn next(&mut self) -> AppResult<Event> {
+        match self.receiver.recv().await {
+            Some(app_result) => AppResult::Ok(app_result),
+            None => AppResult::Err("".into()),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> AppResult<()> {
     // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
-    let events = EventHandler::new(250);
+    let events = EventHandler::new(250); // Tick event every 250ms, this is the minimum update loop speed
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
     // Start the main loop.

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,15 +31,17 @@ async fn main() -> AppResult<()> {
     while app.running {
         tui.draw(&app)?;
 
-        // Handle events.
-        match tui.events.next()? {
+        // Handle events
+        // TODO: The match below is blocking, so it should be corrected in the future
+        // but it will block for at most a tick so it should be imperceptible. 
+        // Tokio requires us not to block the main thread so that it can still poll on futures.
+        match tui.events.next().await? {
             Event::Tick => {
                 app.tick();
             },
             Event::Key(key_event) => handle_key_events(key_event, &app)?,
             Event::Mouse(_) => {},
             Event::Resize(_, _) => {},
-            Event::Nothing => {},
         }
 
         app.poll_and_run_action().await;


### PR DESCRIPTION
This PR allows the main thread to sleep when no events are occurring, in my testing this reduces the app CPU usage from 25% (1 thread using a full core) to 3-6%.

Tokio, our async run-time, runs its polling logic in the main thread. That means that it uses the main thread to check if futures resolve. Therefore it is important that we do not block the man thread, especially if we are awaiting futures, since Tokio cannot resolve futures when the main thread is blocked, leading to a bit of a deadlock.

Previously I added a 'nothing' event, so that we were always running the main loop even when we didn't get an event (Keyboard, resize, tick, etc) so that we wouldn't need to do a blocking await in main (hosting the main thread). This was of course never allowing the main thread to sleep so it was using all resources even when idle. 
This change does perform an await in the main thread, but it is awaiting data to come through a channel from the event thread. We will get an event _at least_ every 250ms, and the event thread is isolated, so the app still runs relatively snappy and (as far as I've seen) doesn't cause deadlocks in Tokio. This drops our idle CPU usage drastically since we now only need to wait on the tick and can sleep the thread while doing so.

### TODO
In future we may want to make the await code 
`tui.events.next().await?`
run in a separate Tokio blocking thread ( `tokio::spawn::spawn_blocking(|| {})` ) to ensure that Tokio can resolve futures even when we need to block the main thread. However I think this would require some larger refactoring than I wanted to do to satisfy the compiler (we would need to move ownership of our variables to the blocking thread) 
